### PR TITLE
Remove dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,6 @@ name: Run tests
 on:
   pull_request:
 
-env:
-  PHP_VERSION: '8.0'
-
 jobs:
 
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Run tests
+
+on:
+  pull_request:
+
+env:
+  PHP_VERSION: '8.0'
+
+jobs:
+
+  tests:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-versions: ['7.4', '8.0', '8.1']
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Validate composer.json
+        run: composer validate
+
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --optimize-autoloader --no-progress --no-interaction
+
+      - name: Run PHPunit tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Here we might need better options.
 
 * Note that the project follows [PSR-2](https://www.php-fig.org/psr/psr-2/) for formatting. 
 
+## TODO
+
+Class `\druidfi\GdprDump\Util\Path` class is copied from `symfony/filesystem:5.4.0` package. When the package
+`drupal/core-dev-pinned` will allow `symfony/filesystem` newer then 5.4 we can remove this class and use
+`symfony/filesystem` instead.
+
 ## Credits
 
 - [machbarmacher/gdpr-dump](https://github.com/machbarmacher/gdpr-dump)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This will replace the given column's value with Faker output.
 
 You can also save replacements mapping to JSON file and use it with `--gdpr-replacements-file` option.
 
-## Use with drush
+## Use with Drush
 
 See [drush-gdpr-dumper](https://github.com/druidfi/drush-gdpr-dumper)
 
@@ -110,6 +110,12 @@ Here we might need better options.
 ## Contributors notes
 
 * Note that the project follows [PSR-2](https://www.php-fig.org/psr/psr-2/) for formatting. 
+
+## Credits
+
+- [machbarmacher/gdpr-dump](https://github.com/machbarmacher/gdpr-dump)
+- [ifsnop/mysqldump-php](https://github.com/ifsnop/mysqldump-php)
+- [Faker](https://fakerphp.github.io/)
 
 ## Other information
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "nette/finder": "^2.5 || ^3.0@dev",
     "symfony/console": "^4.4.25|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",
-    "webmozart/path-util": "^2.3@dev"
+    "symfony/filesystem": "^5.4 || ^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5.15 || ^9"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "cweagans/composer-patches": "^1.7",
     "fakerphp/faker": "^1.20",
     "ifsnop/mysqldump-php": "^2.9",
-    "matomo/ini": "dev-master",
+    "matomo/ini": "^3.0",
     "nette/finder": "^2.5 || ^3.0@dev",
     "symfony/console": "^4.4.25|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,8 @@
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "ext-pdo": "*",
-    "cweagans/composer-patches": "^1.7",
+    "druidfi/mysqldump-php": "dev-code-refactor",
     "fakerphp/faker": "^1.20",
-    "ifsnop/mysqldump-php": "dev-master",
     "matomo/ini": "^3.0",
     "symfony/console": "^4.4.25|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",
@@ -39,18 +38,9 @@
       "druidfi\\GdprDump\\": "src/"
     }
   },
-  "extra": {
-    "patches": {
-      "ifsnop/mysqldump-php": {
-        "Add getter": "https://patch-diff.githubusercontent.com/raw/ifsnop/mysqldump-php/pull/137.patch"
-      }
-    }
-  },
   "minimum-stability": "dev",
   "prefer-stable": true,
   "config": {
-    "allow-plugins": {
-      "cweagans/composer-patches": true
-    }
+    "sort-packages": true
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "fakerphp/faker": "^1.20",
     "ifsnop/mysqldump-php": "^2.9",
     "matomo/ini": "^3.0",
-    "nette/finder": "^2.5 || ^3.0@dev",
     "symfony/console": "^4.4.25|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",
     "symfony/filesystem": "^5.4 || ^6.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "ext-pdo": "*",
     "cweagans/composer-patches": "^1.7",
     "fakerphp/faker": "^1.20",
-    "ifsnop/mysqldump-php": "^2.9",
+    "ifsnop/mysqldump-php": "dev-master",
     "matomo/ini": "^3.0",
     "symfony/console": "^4.4.25|^5.0|^6.0",
     "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "ext-pdo": "*",
-    "druidfi/mysqldump-php": "dev-code-refactor",
+    "druidfi/mysqldump-php": "^1.0.0",
     "fakerphp/faker": "^1.20",
     "matomo/ini": "^3.0",
     "symfony/console": "^4.4.25|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
     "fakerphp/faker": "^1.20",
     "matomo/ini": "^3.0",
     "symfony/console": "^4.4.25|^5.0|^6.0",
-    "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",
-    "symfony/filesystem": "^5.4 || ^6.0"
+    "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5.15 || ^9"

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,24 @@
     {
       "name": "Axel Rutz",
       "email": "axel.rutz@machbarmacher.net"
+    },
+    {
+      "name": "Bomoko",
+      "email": "blaize.kaye@gmail.com"
     }
   ],
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-json": "*",
     "ext-pdo": "*",
-    "bomoko/mysql-cnf-parser": "dev-master",
     "cweagans/composer-patches": "^1.7",
     "fakerphp/faker": "^1.20",
     "ifsnop/mysqldump-php": "^2.9",
+    "matomo/ini": "dev-master",
+    "nette/finder": "^2.5 || ^3.0@dev",
     "symfony/console": "^4.4.25|^5.0|^6.0",
-    "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0"
+    "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0",
+    "webmozart/path-util": "^2.3@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5.15 || ^9"

--- a/src/ConfigParser.php
+++ b/src/ConfigParser.php
@@ -2,8 +2,6 @@
 
 namespace druidfi\GdprDump;
 
-use bomoko\MysqlCnfParser\MysqlCnfParser;
-
 /**
  * Class ConfParser
  *

--- a/src/MysqlCnfParser.php
+++ b/src/MysqlCnfParser.php
@@ -2,14 +2,12 @@
 
 namespace druidfi\GdprDump;
 
-use Nette\Utils\Finder;
 use Matomo\Ini\IniReader;
 use Symfony\Component\Filesystem\Path;
 
 class MysqlCnfParser
 {
-    const FILE_TYPES = ['*.cnf', '*.ini'];
-
+    protected array $extensions = ['cnf', 'ini'];
     protected array $processedFiles = [];
 
     public static function parse($filename): array
@@ -72,9 +70,15 @@ class MysqlCnfParser
     protected function parseDirectory($directoryName): array
     {
         $return = [];
+        $files = [];
 
-        foreach (Finder::findFiles(self::FILE_TYPES)->in($directoryName) as $key => $file) {
-            $return = array_merge_recursive($return, $this->parseIniFile($key));
+        foreach ($this->extensions as $extension) {
+            $glob = sprintf('%s/*.%s', $directoryName, $extension);
+            $files = array_merge($files, glob($glob));
+        }
+
+        foreach ($files as $file) {
+            $return = array_merge_recursive($return, $this->parseIniFile($file));
         }
 
         return $return;

--- a/src/MysqlCnfParser.php
+++ b/src/MysqlCnfParser.php
@@ -3,8 +3,8 @@
 namespace druidfi\GdprDump;
 
 use Nette\Utils\Finder;
-use Webmozart\PathUtil\Path;
 use Matomo\Ini\IniReader;
+use Symfony\Component\Filesystem\Path;
 
 class MysqlCnfParser
 {

--- a/src/MysqlCnfParser.php
+++ b/src/MysqlCnfParser.php
@@ -3,7 +3,7 @@
 namespace druidfi\GdprDump;
 
 use Matomo\Ini\IniReader;
-use Symfony\Component\Filesystem\Path;
+use druidfi\GdprDump\Util\Path;
 
 class MysqlCnfParser
 {

--- a/src/MysqlCnfParser.php
+++ b/src/MysqlCnfParser.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace druidfi\GdprDump;
+
+use Nette\Utils\Finder;
+use Webmozart\PathUtil\Path;
+use Matomo\Ini\IniReader;
+
+class MysqlCnfParser
+{
+    const FILE_TYPES = ['*.cnf', '*.ini'];
+
+    protected array $processedFiles = [];
+
+    public static function parse($filename): array
+    {
+        return (new self())->parseIniFile($filename);
+    }
+
+    public function parseIniFile($filename): array
+    {
+        if (is_file($filename) && is_readable($filename)) {
+            $this->markFileProcessed($filename);
+            $contents = file_get_contents($filename);
+            $contentArray = explode("\n", $contents);
+            //go through the file and pop any "!include/!includedir" directives
+            $reader = new IniReader();
+            $toParse = [];
+            $includes = [];
+            foreach ($contentArray as $line) {
+                if (strpos(trim($line), "!include") === 0) {
+                    $includes[] = $line;
+                } elseif (strlen($line) > 0 && !in_array($line[0],
+                        ["!", "#"])
+                ) { //ignore comments
+                    $toParse[] = $line;
+                }
+            }
+
+            return array_merge_recursive(
+                $reader->readString(implode("\n", $toParse), true),
+                $this->processIncludes($includes,
+                    Path::getDirectory($filename)));
+        } else {
+            return [];
+        }
+    }
+
+    protected function processIncludes(Array $includes, $includePath): array
+    {
+        $return = [];
+
+        foreach ($includes as $include) {
+            //strip any !include(s)
+            $names = explode(" ", $include);
+            $fileName = $names[1];
+            $includeType = $names[0];
+
+            $fileName = Path::makeAbsolute($fileName, $includePath);
+            if (!$this->hasFileBeenProcessed($fileName)) {
+                $this->markFileProcessed($fileName);
+                $return = array_merge_recursive($return,
+                    $includeType == "!includedir" ? $this->parseDirectory($fileName) : $this->parseIniFile($fileName));
+            }
+        }
+        return $return;
+    }
+
+    protected function parseDirectory($directoryName): array
+    {
+        $return = [];
+
+        foreach (Finder::findFiles(self::FILE_TYPES)
+                     ->in($directoryName) as $key => $file) {
+            $return = array_merge_recursive($return, $this->parseIniFile($key));
+        }
+
+        return $return;
+    }
+
+    protected function hasFileBeenProcessed($fileName): bool
+    {
+        return in_array(Path::canonicalize($fileName), $this->processedFiles);
+    }
+
+    protected function markFileProcessed($fileName)
+    {
+        $canonicalFileName = Path::canonicalize($fileName);
+        $this->processedFiles[$canonicalFileName] = $canonicalFileName;
+    }
+}

--- a/src/MysqlCnfParser.php
+++ b/src/MysqlCnfParser.php
@@ -23,24 +23,25 @@ class MysqlCnfParser
             $this->markFileProcessed($filename);
             $contents = file_get_contents($filename);
             $contentArray = explode("\n", $contents);
-            //go through the file and pop any "!include/!includedir" directives
+
+            // Go through the file and pop any "!include/!includedir" directives
             $reader = new IniReader();
             $toParse = [];
             $includes = [];
+
             foreach ($contentArray as $line) {
                 if (strpos(trim($line), "!include") === 0) {
                     $includes[] = $line;
-                } elseif (strlen($line) > 0 && !in_array($line[0],
-                        ["!", "#"])
-                ) { //ignore comments
+                } elseif (strlen($line) > 0 && !in_array($line[0], ["!", "#"])) {
+                    // Ignore comments
                     $toParse[] = $line;
                 }
             }
 
             return array_merge_recursive(
-                $reader->readString(implode("\n", $toParse), true),
-                $this->processIncludes($includes,
-                    Path::getDirectory($filename)));
+                $reader->readString(implode("\n", $toParse)),
+                $this->processIncludes($includes, Path::getDirectory($filename))
+            );
         } else {
             return [];
         }
@@ -51,18 +52,20 @@ class MysqlCnfParser
         $return = [];
 
         foreach ($includes as $include) {
-            //strip any !include(s)
+            // Strip any !include(s).
             $names = explode(" ", $include);
             $fileName = $names[1];
             $includeType = $names[0];
-
             $fileName = Path::makeAbsolute($fileName, $includePath);
+
             if (!$this->hasFileBeenProcessed($fileName)) {
                 $this->markFileProcessed($fileName);
                 $return = array_merge_recursive($return,
-                    $includeType == "!includedir" ? $this->parseDirectory($fileName) : $this->parseIniFile($fileName));
+                    $includeType == "!includedir" ? $this->parseDirectory($fileName) : $this->parseIniFile($fileName)
+                );
             }
         }
+
         return $return;
     }
 
@@ -70,8 +73,7 @@ class MysqlCnfParser
     {
         $return = [];
 
-        foreach (Finder::findFiles(self::FILE_TYPES)
-                     ->in($directoryName) as $key => $file) {
+        foreach (Finder::findFiles(self::FILE_TYPES)->in($directoryName) as $key => $file) {
             $return = array_merge_recursive($return, $this->parseIniFile($key));
         }
 

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -1,0 +1,818 @@
+<?php
+
+/*
+ * This file is part of the Symfony package. It's copied from version 5.4.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace druidfi\GdprDump\Util;
+
+use Exception;
+
+/**
+ * Contains utility methods for handling path strings.
+ *
+ * The methods in this class are able to deal with both UNIX and Windows paths
+ * with both forward and backward slashes. All methods return normalized parts
+ * containing only forward slashes and no excess "." and ".." segments.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Thomas Schulz <mail@king2500.net>
+ * @author Théo Fidry <theo.fidry@gmail.com>
+ */
+final class Path
+{
+    /**
+     * The number of buffer entries that triggers a cleanup operation.
+     */
+    private const CLEANUP_THRESHOLD = 1250;
+
+    /**
+     * The buffer size after the cleanup operation.
+     */
+    private const CLEANUP_SIZE = 1000;
+
+    /**
+     * Buffers input/output of {@link canonicalize()}.
+     *
+     * @var array<string, string>
+     */
+    private static $buffer = [];
+
+    /**
+     * @var int
+     */
+    private static $bufferSize = 0;
+
+    /**
+     * Canonicalizes the given path.
+     *
+     * During normalization, all slashes are replaced by forward slashes ("/").
+     * Furthermore, all "." and ".." segments are removed as far as possible.
+     * ".." segments at the beginning of relative paths are not removed.
+     *
+     * ```php
+     * echo Path::canonicalize("\symfony\puli\..\css\style.css");
+     * // => /symfony/css/style.css
+     *
+     * echo Path::canonicalize("../css/./style.css");
+     * // => ../css/style.css
+     * ```
+     *
+     * This method is able to deal with both UNIX and Windows paths.
+     */
+    public static function canonicalize(string $path): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        // This method is called by many other methods in this class. Buffer
+        // the canonicalized paths to make up for the severe performance
+        // decrease.
+        if (isset(self::$buffer[$path])) {
+            return self::$buffer[$path];
+        }
+
+        // Replace "~" with user's home directory.
+        if ('~' === $path[0]) {
+            $path = self::getHomeDirectory().mb_substr($path, 1);
+        }
+
+        $path = self::normalize($path);
+
+        [$root, $pathWithoutRoot] = self::split($path);
+
+        $canonicalParts = self::findCanonicalParts($root, $pathWithoutRoot);
+
+        // Add the root directory again
+        self::$buffer[$path] = $canonicalPath = $root.implode('/', $canonicalParts);
+        ++self::$bufferSize;
+
+        // Clean up regularly to prevent memory leaks
+        if (self::$bufferSize > self::CLEANUP_THRESHOLD) {
+            self::$buffer = \array_slice(self::$buffer, -self::CLEANUP_SIZE, null, true);
+            self::$bufferSize = self::CLEANUP_SIZE;
+        }
+
+        return $canonicalPath;
+    }
+
+    /**
+     * Normalizes the given path.
+     *
+     * During normalization, all slashes are replaced by forward slashes ("/").
+     * Contrary to {@link canonicalize()}, this method does not remove invalid
+     * or dot path segments. Consequently, it is much more efficient and should
+     * be used whenever the given path is known to be a valid, absolute system
+     * path.
+     *
+     * This method is able to deal with both UNIX and Windows paths.
+     */
+    public static function normalize(string $path): string
+    {
+        return str_replace('\\', '/', $path);
+    }
+
+    /**
+     * Returns the directory part of the path.
+     *
+     * This method is similar to PHP's dirname(), but handles various cases
+     * where dirname() returns a weird result:
+     *
+     *  - dirname() does not accept backslashes on UNIX
+     *  - dirname("C:/symfony") returns "C:", not "C:/"
+     *  - dirname("C:/") returns ".", not "C:/"
+     *  - dirname("C:") returns ".", not "C:/"
+     *  - dirname("symfony") returns ".", not ""
+     *  - dirname() does not canonicalize the result
+     *
+     * This method fixes these shortcomings and behaves like dirname()
+     * otherwise.
+     *
+     * The result is a canonical path.
+     *
+     * @return string The canonical directory part. Returns the root directory
+     *                if the root directory is passed. Returns an empty string
+     *                if a relative path is passed that contains no slashes.
+     *                Returns an empty string if an empty string is passed.
+     */
+    public static function getDirectory(string $path): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $path = self::canonicalize($path);
+
+        // Maintain scheme
+        if (false !== ($schemeSeparatorPosition = mb_strpos($path, '://'))) {
+            $scheme = mb_substr($path, 0, $schemeSeparatorPosition + 3);
+            $path = mb_substr($path, $schemeSeparatorPosition + 3);
+        } else {
+            $scheme = '';
+        }
+
+        if (false === ($dirSeparatorPosition = strrpos($path, '/'))) {
+            return '';
+        }
+
+        // Directory equals root directory "/"
+        if (0 === $dirSeparatorPosition) {
+            return $scheme.'/';
+        }
+
+        // Directory equals Windows root "C:/"
+        if (2 === $dirSeparatorPosition && ctype_alpha($path[0]) && ':' === $path[1]) {
+            return $scheme.mb_substr($path, 0, 3);
+        }
+
+        return $scheme.mb_substr($path, 0, $dirSeparatorPosition);
+    }
+
+    /**
+     * Returns canonical path of the user's home directory.
+     *
+     * Supported operating systems:
+     *
+     *  - UNIX
+     *  - Windows8 and upper
+     *
+     * If your operating system or environment isn't supported, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @throws Exception If your operating system or environment isn't supported
+     */
+    public static function getHomeDirectory(): string
+    {
+        // For UNIX support
+        if (getenv('HOME')) {
+            return self::canonicalize(getenv('HOME'));
+        }
+
+        // For >= Windows8 support
+        if (getenv('HOMEDRIVE') && getenv('HOMEPATH')) {
+            return self::canonicalize(getenv('HOMEDRIVE').getenv('HOMEPATH'));
+        }
+
+        throw new Exception("Cannot find the home directory path: Your environment or operating system isn't supported.");
+    }
+
+    /**
+     * Returns the root directory of a path.
+     *
+     * The result is a canonical path.
+     *
+     * @return string The canonical root directory. Returns an empty string if
+     *                the given path is relative or empty.
+     */
+    public static function getRoot(string $path): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        // Maintain scheme
+        if (false !== ($schemeSeparatorPosition = strpos($path, '://'))) {
+            $scheme = substr($path, 0, $schemeSeparatorPosition + 3);
+            $path = substr($path, $schemeSeparatorPosition + 3);
+        } else {
+            $scheme = '';
+        }
+
+        $firstCharacter = $path[0];
+
+        // UNIX root "/" or "\" (Windows style)
+        if ('/' === $firstCharacter || '\\' === $firstCharacter) {
+            return $scheme.'/';
+        }
+
+        $length = mb_strlen($path);
+
+        // Windows root
+        if ($length > 1 && ':' === $path[1] && ctype_alpha($firstCharacter)) {
+            // Special case: "C:"
+            if (2 === $length) {
+                return $scheme.$path.'/';
+            }
+
+            // Normal case: "C:/ or "C:\"
+            if ('/' === $path[2] || '\\' === $path[2]) {
+                return $scheme.$firstCharacter.$path[1].'/';
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the file name without the extension from a file path.
+     *
+     * @param string|null $extension if specified, only that extension is cut
+     *                               off (may contain leading dot)
+     */
+    public static function getFilenameWithoutExtension(string $path, string $extension = null): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        if (null !== $extension) {
+            // remove extension and trailing dot
+            return rtrim(basename($path, $extension), '.');
+        }
+
+        return pathinfo($path, \PATHINFO_FILENAME);
+    }
+
+    /**
+     * Returns the extension from a file path (without leading dot).
+     *
+     * @param bool $forceLowerCase forces the extension to be lower-case
+     */
+    public static function getExtension(string $path, bool $forceLowerCase = false): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $extension = pathinfo($path, \PATHINFO_EXTENSION);
+
+        if ($forceLowerCase) {
+            $extension = self::toLower($extension);
+        }
+
+        return $extension;
+    }
+
+    /**
+     * Returns whether the path has an (or the specified) extension.
+     *
+     * @param string               $path       the path string
+     * @param string|string[]|null $extensions if null or not provided, checks if
+     *                                         an extension exists, otherwise
+     *                                         checks for the specified extension
+     *                                         or array of extensions (with or
+     *                                         without leading dot)
+     * @param bool                 $ignoreCase whether to ignore case-sensitivity
+     */
+    public static function hasExtension(string $path, $extensions = null, bool $ignoreCase = false): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        $actualExtension = self::getExtension($path, $ignoreCase);
+
+        // Only check if path has any extension
+        if ([] === $extensions || null === $extensions) {
+            return '' !== $actualExtension;
+        }
+
+        if (\is_string($extensions)) {
+            $extensions = [$extensions];
+        }
+
+        foreach ($extensions as $key => $extension) {
+            if ($ignoreCase) {
+                $extension = self::toLower($extension);
+            }
+
+            // remove leading '.' in extensions array
+            $extensions[$key] = ltrim($extension, '.');
+        }
+
+        return \in_array($actualExtension, $extensions, true);
+    }
+
+    /**
+     * Changes the extension of a path string.
+     *
+     * @param string $path      The path string with filename.ext to change.
+     * @param string $extension new extension (with or without leading dot)
+     *
+     * @return string the path string with new file extension
+     */
+    public static function changeExtension(string $path, string $extension): string
+    {
+        if ('' === $path) {
+            return '';
+        }
+
+        $actualExtension = self::getExtension($path);
+        $extension = ltrim($extension, '.');
+
+        // No extension for paths
+        if ('/' === mb_substr($path, -1)) {
+            return $path;
+        }
+
+        // No actual extension in path
+        if (empty($actualExtension)) {
+            return $path.('.' === mb_substr($path, -1) ? '' : '.').$extension;
+        }
+
+        return mb_substr($path, 0, -mb_strlen($actualExtension)).$extension;
+    }
+
+    public static function isAbsolute(string $path): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        // Strip scheme
+        if (false !== ($schemeSeparatorPosition = mb_strpos($path, '://'))) {
+            $path = mb_substr($path, $schemeSeparatorPosition + 3);
+        }
+
+        $firstCharacter = $path[0];
+
+        // UNIX root "/" or "\" (Windows style)
+        if ('/' === $firstCharacter || '\\' === $firstCharacter) {
+            return true;
+        }
+
+        // Windows root
+        if (mb_strlen($path) > 1 && ctype_alpha($firstCharacter) && ':' === $path[1]) {
+            // Special case: "C:"
+            if (2 === mb_strlen($path)) {
+                return true;
+            }
+
+            // Normal case: "C:/ or "C:\"
+            if ('/' === $path[2] || '\\' === $path[2]) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function isRelative(string $path): bool
+    {
+        return !self::isAbsolute($path);
+    }
+
+    /**
+     * Turns a relative path into an absolute path in canonical form.
+     *
+     * Usually, the relative path is appended to the given base path. Dot
+     * segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * echo Path::makeAbsolute("../style.css", "/symfony/puli/css");
+     * // => /symfony/puli/style.css
+     * ```
+     *
+     * If an absolute path is passed, that path is returned unless its root
+     * directory is different than the one of the base path. In that case, an
+     * exception is thrown.
+     *
+     * ```php
+     * Path::makeAbsolute("/style.css", "/symfony/puli/css");
+     * // => /style.css
+     *
+     * Path::makeAbsolute("C:/style.css", "C:/symfony/puli/css");
+     * // => C:/style.css
+     *
+     * Path::makeAbsolute("C:/style.css", "/symfony/puli/css");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the base path is not an absolute path, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @param string $basePath an absolute base path
+     *
+     * @throws Exception if the base path is not absolute or if
+     *                                  the given path is an absolute path with
+     *                                  a different root than the base path
+     */
+    public static function makeAbsolute(string $path, string $basePath): string
+    {
+        if ('' === $basePath) {
+            throw new Exception(sprintf('The base path must be a non-empty string. Got: "%s".', $basePath));
+        }
+
+        if (!self::isAbsolute($basePath)) {
+            throw new Exception(sprintf('The base path "%s" is not an absolute path.', $basePath));
+        }
+
+        if (self::isAbsolute($path)) {
+            return self::canonicalize($path);
+        }
+
+        if (false !== ($schemeSeparatorPosition = mb_strpos($basePath, '://'))) {
+            $scheme = mb_substr($basePath, 0, $schemeSeparatorPosition + 3);
+            $basePath = mb_substr($basePath, $schemeSeparatorPosition + 3);
+        } else {
+            $scheme = '';
+        }
+
+        return $scheme.self::canonicalize(rtrim($basePath, '/\\').'/'.$path);
+    }
+
+    /**
+     * Turns a path into a relative path.
+     *
+     * The relative path is created relative to the given base path:
+     *
+     * ```php
+     * echo Path::makeRelative("/symfony/style.css", "/symfony/puli");
+     * // => ../style.css
+     * ```
+     *
+     * If a relative path is passed and the base path is absolute, the relative
+     * path is returned unchanged:
+     *
+     * ```php
+     * Path::makeRelative("style.css", "/symfony/puli/css");
+     * // => style.css
+     * ```
+     *
+     * If both paths are relative, the relative path is created with the
+     * assumption that both paths are relative to the same directory:
+     *
+     * ```php
+     * Path::makeRelative("style.css", "symfony/puli/css");
+     * // => ../../../style.css
+     * ```
+     *
+     * If both paths are absolute, their root directory must be the same,
+     * otherwise an exception is thrown:
+     *
+     * ```php
+     * Path::makeRelative("C:/symfony/style.css", "/symfony/puli");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the passed path is absolute, but the base path is not, an exception
+     * is thrown as well:
+     *
+     * ```php
+     * Path::makeRelative("/symfony/style.css", "symfony/puli");
+     * // InvalidArgumentException
+     * ```
+     *
+     * If the base path is not an absolute path, an exception is thrown.
+     *
+     * The result is a canonical path.
+     *
+     * @throws Exception if the base path is not absolute or if
+     *                                  the given path has a different root
+     *                                  than the base path
+     */
+    public static function makeRelative(string $path, string $basePath): string
+    {
+        $path = self::canonicalize($path);
+        $basePath = self::canonicalize($basePath);
+
+        [$root, $relativePath] = self::split($path);
+        [$baseRoot, $relativeBasePath] = self::split($basePath);
+
+        // If the base path is given as absolute path and the path is already
+        // relative, consider it to be relative to the given absolute path
+        // already
+        if ('' === $root && '' !== $baseRoot) {
+            // If base path is already in its root
+            if ('' === $relativeBasePath) {
+                $relativePath = ltrim($relativePath, './\\');
+            }
+
+            return $relativePath;
+        }
+
+        // If the passed path is absolute, but the base path is not, we
+        // cannot generate a relative path
+        if ('' !== $root && '' === $baseRoot) {
+            throw new Exception(sprintf('The absolute path "%s" cannot be made relative to the relative path "%s". You should provide an absolute base path instead.', $path, $basePath));
+        }
+
+        // Fail if the roots of the two paths are different
+        if ($baseRoot && $root !== $baseRoot) {
+            throw new Exception(sprintf('The path "%s" cannot be made relative to "%s", because they have different roots ("%s" and "%s").', $path, $basePath, $root, $baseRoot));
+        }
+
+        if ('' === $relativeBasePath) {
+            return $relativePath;
+        }
+
+        // Build a "../../" prefix with as many "../" parts as necessary
+        $parts = explode('/', $relativePath);
+        $baseParts = explode('/', $relativeBasePath);
+        $dotDotPrefix = '';
+
+        // Once we found a non-matching part in the prefix, we need to add
+        // "../" parts for all remaining parts
+        $match = true;
+
+        foreach ($baseParts as $index => $basePart) {
+            if ($match && isset($parts[$index]) && $basePart === $parts[$index]) {
+                unset($parts[$index]);
+
+                continue;
+            }
+
+            $match = false;
+            $dotDotPrefix .= '../';
+        }
+
+        return rtrim($dotDotPrefix.implode('/', $parts), '/');
+    }
+
+    /**
+     * Returns whether the given path is on the local filesystem.
+     */
+    public static function isLocal(string $path): bool
+    {
+        return '' !== $path && false === mb_strpos($path, '://');
+    }
+
+    /**
+     * Returns the longest common base path in canonical form of a set of paths or
+     * `null` if the paths are on different Windows partitions.
+     *
+     * Dot segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(
+     *     '/symfony/css/style.css',
+     *     '/symfony/css/..'
+     * );
+     * // => /symfony
+     * ```
+     *
+     * The root is returned if no common base path can be found:
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(
+     *     '/symfony/css/style.css',
+     *     '/puli/css/..'
+     * );
+     * // => /
+     * ```
+     *
+     * If the paths are located on different Windows partitions, `null` is
+     * returned.
+     *
+     * ```php
+     * $basePath = Path::getLongestCommonBasePath(
+     *     'C:/symfony/css/style.css',
+     *     'D:/symfony/css/..'
+     * );
+     * // => null
+     * ```
+     */
+    public static function getLongestCommonBasePath(string ...$paths): ?string
+    {
+        [$bpRoot, $basePath] = self::split(self::canonicalize(reset($paths)));
+
+        for (next($paths); null !== key($paths) && '' !== $basePath; next($paths)) {
+            [$root, $path] = self::split(self::canonicalize(current($paths)));
+
+            // If we deal with different roots (e.g. C:/ vs. D:/), it's time
+            // to quit
+            if ($root !== $bpRoot) {
+                return null;
+            }
+
+            // Make the base path shorter until it fits into path
+            while (true) {
+                if ('.' === $basePath) {
+                    // No more base paths
+                    $basePath = '';
+
+                    // next path
+                    continue 2;
+                }
+
+                // Prevent false positives for common prefixes
+                // see isBasePath()
+                if (0 === mb_strpos($path.'/', $basePath.'/')) {
+                    // next path
+                    continue 2;
+                }
+
+                $basePath = \dirname($basePath);
+            }
+        }
+
+        return $bpRoot.$basePath;
+    }
+
+    /**
+     * Joins two or more path strings into a canonical path.
+     */
+    public static function join(string ...$paths): string
+    {
+        $finalPath = null;
+        $wasScheme = false;
+
+        foreach ($paths as $path) {
+            if ('' === $path) {
+                continue;
+            }
+
+            if (null === $finalPath) {
+                // For first part we keep slashes, like '/top', 'C:\' or 'phar://'
+                $finalPath = $path;
+                $wasScheme = (false !== mb_strpos($path, '://'));
+                continue;
+            }
+
+            // Only add slash if previous part didn't end with '/' or '\'
+            if (!\in_array(mb_substr($finalPath, -1), ['/', '\\'])) {
+                $finalPath .= '/';
+            }
+
+            // If first part included a scheme like 'phar://' we allow \current part to start with '/', otherwise trim
+            $finalPath .= $wasScheme ? $path : ltrim($path, '/');
+            $wasScheme = false;
+        }
+
+        if (null === $finalPath) {
+            return '';
+        }
+
+        return self::canonicalize($finalPath);
+    }
+
+    /**
+     * Returns whether a path is a base path of another path.
+     *
+     * Dot segments ("." and "..") are removed/collapsed and all slashes turned
+     * into forward slashes.
+     *
+     * ```php
+     * Path::isBasePath('/symfony', '/symfony/css');
+     * // => true
+     *
+     * Path::isBasePath('/symfony', '/symfony');
+     * // => true
+     *
+     * Path::isBasePath('/symfony', '/symfony/..');
+     * // => false
+     *
+     * Path::isBasePath('/symfony', '/puli');
+     * // => false
+     * ```
+     */
+    public static function isBasePath(string $basePath, string $ofPath): bool
+    {
+        $basePath = self::canonicalize($basePath);
+        $ofPath = self::canonicalize($ofPath);
+
+        // Append slashes to prevent false positives when two paths have
+        // a common prefix, for example /base/foo and /base/foobar.
+        // Don't append a slash for the root "/", because then that root
+        // won't be discovered as common prefix ("//" is not a prefix of
+        // "/foobar/").
+        return 0 === mb_strpos($ofPath.'/', rtrim($basePath, '/').'/');
+    }
+
+    /**
+     * @return non-empty-string[]
+     */
+    private static function findCanonicalParts(string $root, string $pathWithoutRoot): array
+    {
+        $parts = explode('/', $pathWithoutRoot);
+
+        $canonicalParts = [];
+
+        // Collapse "." and "..", if possible
+        foreach ($parts as $part) {
+            if ('.' === $part || '' === $part) {
+                continue;
+            }
+
+            // Collapse ".." with the previous part, if one exists
+            // Don't collapse ".." if the previous part is also ".."
+            if ('..' === $part && \count($canonicalParts) > 0 && '..' !== $canonicalParts[\count($canonicalParts) - 1]) {
+                array_pop($canonicalParts);
+
+                continue;
+            }
+
+            // Only add ".." prefixes for relative paths
+            if ('..' !== $part || '' === $root) {
+                $canonicalParts[] = $part;
+            }
+        }
+
+        return $canonicalParts;
+    }
+
+    /**
+     * Splits a canonical path into its root directory and the remainder.
+     *
+     * If the path has no root directory, an empty root directory will be
+     * returned.
+     *
+     * If the root directory is a Windows style partition, the resulting root
+     * will always contain a trailing slash.
+     *
+     * list ($root, $path) = Path::split("C:/symfony")
+     * // => ["C:/", "symfony"]
+     *
+     * list ($root, $path) = Path::split("C:")
+     * // => ["C:/", ""]
+     *
+     * @return array{string, string} an array with the root directory and the remaining relative path
+     */
+    private static function split(string $path): array
+    {
+        if ('' === $path) {
+            return ['', ''];
+        }
+
+        // Remember scheme as part of the root, if any
+        if (false !== ($schemeSeparatorPosition = mb_strpos($path, '://'))) {
+            $root = mb_substr($path, 0, $schemeSeparatorPosition + 3);
+            $path = mb_substr($path, $schemeSeparatorPosition + 3);
+        } else {
+            $root = '';
+        }
+
+        $length = mb_strlen($path);
+
+        // Remove and remember root directory
+        if (0 === mb_strpos($path, '/')) {
+            $root .= '/';
+            $path = $length > 1 ? mb_substr($path, 1) : '';
+        } elseif ($length > 1 && ctype_alpha($path[0]) && ':' === $path[1]) {
+            if (2 === $length) {
+                // Windows special case: "C:"
+                $root .= $path.'/';
+                $path = '';
+            } elseif ('/' === $path[2]) {
+                // Windows normal case: "C:/"..
+                $root .= mb_substr($path, 0, 3);
+                $path = $length > 3 ? mb_substr($path, 3) : '';
+            }
+        }
+
+        return [$root, $path];
+    }
+
+    private static function toLower(string $string): string
+    {
+        if (false !== $encoding = mb_detect_encoding($string)) {
+            return mb_strtolower($string, $encoding);
+        }
+
+        return strtolower($string, $encoding);
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/tests/MysqlCnfParserTest.php
+++ b/tests/MysqlCnfParserTest.php
@@ -30,7 +30,7 @@ class MysqlCnfParserTest extends TestCase
     public function testParseCndWithIncludeDirectory()
     {
         $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfIncludesDirectory.cnf");
-        $this->assertArrayHasKey("included", $output);
+        $this->assertArrayHasKey("included", $output, print_r($output, true));
     }
 
     /**

--- a/tests/MysqlCnfParserTest.php
+++ b/tests/MysqlCnfParserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use druidfi\GdprDump\MysqlCnfParser;
+
+class MysqlCnfParserTest extends TestCase
+{
+    /**
+     * @covers MysqlCnfParser::parse
+     */
+    public function testParseCnfWithoutIncludes()
+    {
+        $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfWithoutIncludes.cnf");
+        $this->assertTrue(is_array($output));
+        $this->assertArrayHasKey("client", $output);
+    }
+
+    /**
+     * @covers MysqlCnfParser::parse
+     */
+    public function testParseCndWithIncludeFile()
+    {
+        $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfWithIncludeFile.cnf");
+        $this->assertArrayHasKey("included", $output);
+    }
+
+    /**
+     * @covers MysqlCnfParser::parse
+     */
+    public function testParseCndWithIncludeDirectory()
+    {
+        $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfIncludesDirectory.cnf");
+        $this->assertArrayHasKey("included", $output);
+    }
+
+    /**
+     * @covers MysqlCnfParser::parse
+     */
+    public function testParseCndWithIncludeDirectoryWithMultipleFiles()
+    {
+        $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfIncludesDirectory.cnf");
+        $this->assertArrayHasKey("included", $output);
+        $this->assertArrayHasKey("includedmore", $output["included"]);
+        $this->assertArrayHasKey("includedisini", $output["included"]);
+    }
+
+    /**
+     * @covers MysqlCnfParser::parse
+     */
+    public function testDealWithSelfReferentialIncludes()
+    {
+        $output = MysqlCnfParser::parse(__DIR__ . "/assets/cnfInfiniteInclude.cnf");
+        $this->assertArrayHasKey("infinite", $output);
+    }
+}

--- a/tests/assets/cnfIncludesDirectory.cnf
+++ b/tests/assets/cnfIncludesDirectory.cnf
@@ -1,0 +1,14 @@
+[client]
+port=3306
+socket=/tmp/mysql.sock
+
+[mysqld]
+port=3306
+socket=/tmp/mysql.sock
+key_buffer_size=16M
+max_allowed_packet=8M
+
+[mysqldump]
+quick
+
+!includedir includes

--- a/tests/assets/cnfInfiniteInclude.cnf
+++ b/tests/assets/cnfInfiniteInclude.cnf
@@ -1,0 +1,2 @@
+infinite=nope
+!include cnfInfiniteInclude.cnf

--- a/tests/assets/cnfWithIncludeFile.cnf
+++ b/tests/assets/cnfWithIncludeFile.cnf
@@ -1,0 +1,14 @@
+[client]
+port=3306
+socket=/tmp/mysql.sock
+
+[mysqld]
+port=3306
+socket=/tmp/mysql.sock
+key_buffer_size=16M
+max_allowed_packet=8M
+
+[mysqldump]
+quick
+
+!include includes/included.cnf

--- a/tests/assets/cnfWithoutIncludes.cnf
+++ b/tests/assets/cnfWithoutIncludes.cnf
@@ -1,0 +1,12 @@
+[client]
+port=3306
+socket=/tmp/mysql.sock
+
+[mysqld]
+port=3306
+socket=/tmp/mysql.sock
+key_buffer_size=16M
+max_allowed_packet=8M
+
+[mysqldump]
+quick

--- a/tests/assets/includes/included.cnf
+++ b/tests/assets/includes/included.cnf
@@ -1,0 +1,2 @@
+[included]
+includedvalue=777

--- a/tests/assets/includes/includedini.ini
+++ b/tests/assets/includes/includedini.ini
@@ -1,0 +1,5 @@
+key = value
+another_key = another value
+
+[included]
+includedisini = yet another value

--- a/tests/assets/includes/includedmore.cnf
+++ b/tests/assets/includes/includedmore.cnf
@@ -1,0 +1,2 @@
+[included]
+includedmore=789


### PR DESCRIPTION
- Require `druidfi/mysqldump-php` instead of `ifsnop/mysqldump-php`
- Move `bomoko/mysql-cnf-parser` class & tests to this repo
- Replace deprecated `webmozart/path-util` with `symfony/filesystem` package's `Path` class
- Run PHPunit tests with GHA
- Make Drupal 9.4 compatible by copying Path class from symfony/filesystem