### PR TITLE
V2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,7 @@
 {
-  "baseBranches": [
-    "main"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":preserveSemverRanges",
     ":disableRateLimiting"
   ],
@@ -15,5 +13,8 @@
   "timezone": "Europe/Helsinki",
   "vulnerabilityAlerts": {
     "labels": ["security"]
-  }
+  },
+  "baseBranches": [
+    "main"
+  ]
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
 
     steps:
 

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.2",
     "ext-json": "*",
     "ext-pdo": "*",
-    "druidfi/mysqldump-php": "^1.1.0",
+    "druidfi/mysqldump-php": "^2.0.0@rc",
     "fakerphp/faker": "^1.20",
     "matomo/ini": "^3.0",
     "symfony/console": "^4.4.25|^5.0|^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     "druidfi/mysqldump-php": "^2.0.0@rc",
     "fakerphp/faker": "^1.20",
     "matomo/ini": "^3.0",
-    "symfony/console": "^4.4.25|^5.0|^6.0|^7.0",
-    "symfony/event-dispatcher": "^4.4.25|^5.0|^6.0|^7.0"
+    "symfony/console": "^5.4|^6.4|^7.2",
+    "symfony/event-dispatcher": "^5.4|^6.4|^7.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5.15 || ^9"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php": "^8.2",
     "ext-json": "*",
     "ext-pdo": "*",
-    "druidfi/mysqldump-php": "^2.0.0@rc",
+    "druidfi/mysqldump-php": "^2.0",
     "fakerphp/faker": "^1.20",
     "matomo/ini": "^3.0",
     "symfony/console": "^5.4|^6.4|^7.2",


### PR DESCRIPTION
- Drop support for unsupported PHP versions (PHP 8.1 and older)
- Requite druidfi/mysqldump-php v2
- Drop support for unsupported Symfony versions