### PR TITLE
Fixed compatibility issues with symfony/console:7.2 and PHP 8.4.

### DIFF
--- a/src/Command/DumpCommand.php
+++ b/src/Command/DumpCommand.php
@@ -160,7 +160,7 @@ class DumpCommand extends Command
         return $password;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $dumpSettings =
             $this->getOptOptions($input->getOption('opt'))

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -256,7 +256,7 @@ final class Path
      * @param string|null $extension if specified, only that extension is cut
      *                               off (may contain leading dot)
      */
-    public static function getFilenameWithoutExtension(string $path, string $extension = null): string
+    public static function getFilenameWithoutExtension(string $path, ?string $extension = null): string
     {
         if ('' === $path) {
             return '';


### PR DESCRIPTION
Fatal error with `symfony/console:7.2`:
```
PHP Fatal error:  Declaration of druidfi\GdprDump\Command\DumpCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /app/vendor/druidfi/gdpr-mysqldump/src/Command/DumpCommand.php on line 163
```

Deprecation notice on PHP 8.4:
```
PHP Deprecated:  druidfi\GdprDump\Util\Path::getFilenameWithoutExtension(): Implicitly marking parameter $extension ll in /app/vendor/druidfi/gdpr-mysqldump/src/Util/Path.php on line 259
```